### PR TITLE
Minor UI improvement: Scroll Log to last message by default

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"runtime"
 )
 
 type Client struct {
@@ -177,9 +176,8 @@ func (client *Client) setupUI() {
 
 	client.logTextbox = tview.NewTextView()
 	client.logTextbox.SetBorder(true).SetTitle("Log").SetTitleAlign(tview.AlignLeft)
-	if runtime.GOOS == "windows" {
-	  client.logTextbox.SetScrollable(false) //mouse click and scroll not available so show only last messages
-    }
+
+	client.logTextbox.ScrollToEnd()
 
 	client.app = tview.NewApplication()
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -307,7 +307,7 @@ func (client *Client) selectActivePlot(row int, column int) {
 			s += line
 		}
 	}
-	client.logTextbox.SetText(s)
+	client.logTextbox.SetText(strings.TrimSpace(s))
 }
 
 func (client *Client) selectArchivedPlot(row int, column int) {
@@ -317,7 +317,7 @@ func (client *Client) selectArchivedPlot(row int, column int) {
 			s += line
 		}
 	}
-	client.logTextbox.SetText(s)
+	client.logTextbox.SetText(strings.TrimSpace(s))
 }
 
 func (client *Client) computeAvgTargetTime(host, path string) string {

--- a/internal/client.go
+++ b/internal/client.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"runtime"
 )
 
 type Client struct {
@@ -176,6 +177,9 @@ func (client *Client) setupUI() {
 
 	client.logTextbox = tview.NewTextView()
 	client.logTextbox.SetBorder(true).SetTitle("Log").SetTitleAlign(tview.AlignLeft)
+	if runtime.GOOS == "windows" {
+	  client.logTextbox.SetScrollable(false) //mouse click and scroll not available so show only last messages
+    }
 
 	client.app = tview.NewApplication()
 


### PR DESCRIPTION
Proposal to scroll Log section till last message by default. Currently it shows first messages received from server (e.g server send 20 messages and UI show first 5 of them). User need to scroll to see latest message.
It mostly benefits Windows users, as mouse is disabled here, so no possibility to scroll logs.

P.S. I am new to GitHub. Feel free to tell, if I am doing something wrong.