### PR TITLE
Add SavePlotLogs setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ eg. plotng -ui -host plotter1:8484,plotter2,plotter3:8485
         "MaxActivePlotPerTemp": 0,
         "UseTargetForTmp2": false,
         "BucketSize": 0,
-        "SavePlotLogs": false
+        "SavePlotLogDir": ""
     }
 
 Please note for Windows, please use capital drive letter and '/'  eg.  "D:/temp"
@@ -86,6 +86,6 @@ Please note for Windows, please use capital drive letter and '/'  eg.  "D:/temp"
 - MaxActivePlotPerPhase1 : Maximum active plots per Phase 1 (default: 0 - no limit)
 - UseTargetForTmp2 : use target directory for tmp2
 - BucketSize : specify custom busket size (default: 0 - use chia default)
-- SavePlotLogs : saves logs to `.chia/mainnet/plotter/plotng_log_PLOTID.txt` (default: false)
+- SavePlotLogDir : saves plotting logs to this directory. logs are not saved if no directory is provided (default: "")
 
 Please note PlotNG now skips any destination directory which have less than 105GB of disk space, if you set DiskSpaceCheck to true.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ eg. plotng -ui -host plotter1:8484,plotter2,plotter3:8485
         "DelaysBetweenPlot": 0,
         "MaxActivePlotPerTemp": 0,
         "UseTargetForTmp2": false,
-        "BucketSize": 0
+        "BucketSize": 0,
+        "SavePlotLogs": false
     }
 
 Please note for Windows, please use capital drive letter and '/'  eg.  "D:/temp"
@@ -85,5 +86,6 @@ Please note for Windows, please use capital drive letter and '/'  eg.  "D:/temp"
 - MaxActivePlotPerPhase1 : Maximum active plots per Phase 1 (default: 0 - no limit)
 - UseTargetForTmp2 : use target directory for tmp2
 - BucketSize : specify custom busket size (default: 0 - use chia default)
+- SavePlotLogs : saves logs to `.chia/mainnet/plotter/plotng_log_PLOTID.txt` (default: false)
 
 Please note PlotNG now skips any destination directory which have less than 105GB of disk space, if you set DiskSpaceCheck to true.

--- a/config.json
+++ b/config.json
@@ -16,5 +16,6 @@
   "MaxActivePlotPerTemp": 0,
   "MaxActivePlotPerPhase1": 0,
   "UseTargetForTmp2": false,
-  "BucketSize": 0
+  "BucketSize": 0,
+  "SavePlotLogs": true
 }

--- a/config.json
+++ b/config.json
@@ -17,5 +17,5 @@
   "MaxActivePlotPerPhase1": 0,
   "UseTargetForTmp2": false,
   "BucketSize": 0,
-  "SavePlotLogs": true
+  "SavePlotLogDir": ""
 }

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -157,7 +157,7 @@ func (ap *ActivePlot) RunPlot() {
 
 func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 	reader := bufio.NewReader(in)
-	var f *os.File
+	var logFile *os.File
 	for {
 		if s, err := reader.ReadString('\n'); err != nil {
 			break
@@ -180,13 +180,13 @@ func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 					if err != nil {
 						break
 					}
-					fpath := filepath.Join(userHomeDir, ".chia", "mainnet", "plotter", fmt.Sprintf("plotng_log_%s.txt", ap.Id))
-					f, err = os.Create(fpath)
+					logFilePath := filepath.Join(userHomeDir, ".chia", "mainnet", "plotter", fmt.Sprintf("plotng_log_%s.txt", ap.Id))
+					logFile, err = os.Create(logFilePath)
 					if err != nil {
 						break
 					}
 					for _, l := range ap.Tail {
-						f.Write([]byte(l))
+						logFile.Write([]byte(l))
 					}
 				}
 			}
@@ -197,8 +197,8 @@ func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 				}
 			}
 			ap.lock.Lock()
-			if f != nil {
-				f.Write([]byte(s))
+			if logFile != nil {
+				logFile.Write([]byte(s))
 			}
 			ap.Tail = append(ap.Tail, s)
 			if len(ap.Tail) > 20 {

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -51,7 +51,7 @@ type ActivePlot struct {
 	Pid              int
 	UseTargetForTmp2 bool
 	BucketSize       int
-	SavePlotLogs     bool
+	SavePlotLogDir   string
 	process          *os.Process
 }
 
@@ -175,12 +175,8 @@ func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 			}
 			if strings.HasPrefix(s, "ID: ") {
 				ap.Id = strings.TrimSuffix(s[4:], "\n")
-				if ap.SavePlotLogs {
-					userHomeDir, err := os.UserHomeDir()
-					if err != nil {
-						break
-					}
-					logFilePath := filepath.Join(userHomeDir, ".chia", "mainnet", "plotter", fmt.Sprintf("plotng_log_%s.txt", ap.Id))
+				if len(ap.SavePlotLogDir) > 0 {
+					logFilePath := filepath.Join(ap.SavePlotLogDir, fmt.Sprintf("plotng_log_%s.txt", ap.Id))
 					logFile, err = os.Create(logFilePath)
 					if err != nil {
 						break

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -27,6 +27,7 @@ type Config struct {
 	MaxActivePlotPerPhase1 int
 	UseTargetForTmp2       bool
 	BucketSize             int
+	SavePlotLogs           bool
 }
 
 type PlotConfig struct {

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -27,7 +27,7 @@ type Config struct {
 	MaxActivePlotPerPhase1 int
 	UseTargetForTmp2       bool
 	BucketSize             int
-	SavePlotLogs           bool
+	SavePlotLogDir         string
 }
 
 type PlotConfig struct {

--- a/internal/server.go
+++ b/internal/server.go
@@ -141,6 +141,7 @@ func (server *Server) createNewPlot(config *Config) {
 		DisableBitField:  config.DisableBitField,
 		UseTargetForTmp2: config.UseTargetForTmp2,
 		BucketSize:       config.BucketSize,
+		SavePlotLogs:     config.SavePlotLogs,
 		Phase:            "NA",
 		Tail:             nil,
 		State:            PlotRunning,

--- a/internal/server.go
+++ b/internal/server.go
@@ -141,7 +141,7 @@ func (server *Server) createNewPlot(config *Config) {
 		DisableBitField:  config.DisableBitField,
 		UseTargetForTmp2: config.UseTargetForTmp2,
 		BucketSize:       config.BucketSize,
-		SavePlotLogs:     config.SavePlotLogs,
+		SavePlotLogDir:   config.SavePlotLogDir,
 		Phase:            "NA",
 		Tail:             nil,
 		State:            PlotRunning,


### PR DESCRIPTION
In reference to #17 and #32 

I have added a `SavePlotLogs` setting that writes to `~/.chia/mainnet/plotter/plotng_log_ID.txt`. This should be cross platform as it uses os specific separators when creating the file.