### PR TITLE
Explicitly close log file after plot finishes

### DIFF
--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -278,6 +278,9 @@ func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 			ap.lock.Unlock()
 		}
 	}
+	if logFile != nil {
+		logFile.Close()
+	}
 	return
 }
 


### PR DESCRIPTION
While `logFile` should be garbage collected eventually, it's best to explicitly close the file after we're done with it.