### PR TITLE
Tidying up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module plotng
 go 1.16
 
 require (
-	github.com/gdamore/tcell v1.4.0 // indirect
 	github.com/gdamore/tcell/v2 v2.3.1
 	github.com/ricochet2200/go-disk-usage v0.0.0-20150921141558-f0d1b743428f
 	github.com/rivo/tview v0.0.0-20210312174852-ae9464cc3598

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -216,21 +216,21 @@ func (ap *activePlot) RunPlot() {
 		log.Printf("Failed to start chia command: %s", err)
 		ap.State = plotError
 		return
-	} else {
-		ap.process = cmd.Process
-		ap.Pid = cmd.Process.Pid
-		if err := cmd.Wait(); err != nil {
-			if ap.State != PlotKilled {
-				ap.State = PlotError
-				log.Printf("Plotting Exit with Error: %s", err)
-			} else {
-				log.Printf("Plot [%s] Killed", ap.Id)
-			}
-			ap.cleanup()
-			return
-		}
 	}
-	ap.State = PlotFinished
+
+	ap.process = cmd.Process
+	ap.Pid = cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		if ap.State != plotKilled {
+			ap.State = plotError
+			log.Printf("Plotting Exit with Error: %s", err)
+		} else {
+			log.Printf("Plot [%s] Killed", ap.ID)
+		}
+		ap.cleanup()
+		return
+	}
+	ap.State = plotFinished
 	return
 }
 

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -210,8 +210,6 @@ func (ap *activePlot) RunPlot() {
 	}
 	go ap.processLogs(stdout)
 
-	//log.Println(cmd.String())
-
 	if err := cmd.Start(); err != nil {
 		log.Printf("Failed to start chia command: %s", err)
 		ap.State = plotError

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -254,7 +254,7 @@ func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 					logFilePath := filepath.Join(ap.SavePlotLogDir, fmt.Sprintf("plotng_log_%s.txt", ap.Id))
 					logFile, err = os.Create(logFilePath)
 					if err != nil {
-						fmt.Sprintf("Failed to create log file [%s]: %s", logFilePath, err)
+						log.Printf("Failed to create log file [%s]: %s", logFilePath, err)
 					} else {
 						for _, l := range ap.Tail {
 							logFile.Write([]byte(l))

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -30,7 +30,7 @@ const (
 	plotKilled
 )
 
-type activePlot struct {
+type ActivePlot struct {
 	PlotID          int64
 	StartTime       time.Time
 	EndTime         time.Time
@@ -64,7 +64,7 @@ type activePlot struct {
 // of the entire plot, and phase 4 is the end time of the entire plot.
 // TODO: We can change the ActivePlot structure to be PhaseTime [5]time.Time,
 //       but that's a protocol change.
-func (ap *activePlot) getPhaseTime(phase int) time.Time {
+func (ap *ActivePlot) getPhaseTime(phase int) time.Time {
 	switch phase {
 	case 0:
 		return ap.StartTime
@@ -83,7 +83,7 @@ func (ap *activePlot) getPhaseTime(phase int) time.Time {
 
 // getCurrentPhase returns the current phase, or a negative number to indicate an error.
 // TODO: We can also change this to be part of the structure, but that's also a protocol change.
-func (ap *activePlot) getCurrentPhase() int {
+func (ap *ActivePlot) getCurrentPhase() int {
 	parts := strings.Split(ap.Phase, "/")
 	if len(parts) != 2 {
 		return -1
@@ -96,7 +96,7 @@ func (ap *activePlot) getCurrentPhase() int {
 
 // getProgress returns the current progress, or a negative number to indicate an error
 // TODO: We can also change this to be part of the structure, but that's also a protocol change.
-func (ap *activePlot) getProgress() int {
+func (ap *ActivePlot) getProgress() int {
 	if len(ap.Progress) == 0 {
 		return -1
 	} else if i, err := strconv.Atoi(ap.Progress[:len(ap.Progress)-1]); err != nil {
@@ -106,11 +106,11 @@ func (ap *activePlot) getProgress() int {
 	}
 }
 
-func (ap *activePlot) Duration(currentTime time.Time) string {
+func (ap *ActivePlot) Duration(currentTime time.Time) string {
 	return durationString(currentTime.Sub(ap.StartTime))
 }
 
-func (ap *activePlot) String(showLog bool) string {
+func (ap *ActivePlot) String(showLog bool) string {
 	ap.lock.RLock()
 	state := "Unknown"
 	switch ap.State {
@@ -131,7 +131,7 @@ func (ap *activePlot) String(showLog bool) string {
 	return s
 }
 
-func (ap *activePlot) RunPlot() {
+func (ap *ActivePlot) RunPlot() {
 	ap.StartTime = time.Now()
 	defer func() {
 		ap.EndTime = time.Now()
@@ -232,7 +232,7 @@ func (ap *activePlot) RunPlot() {
 	return
 }
 
-func (ap *activePlot) processLogs(in io.ReadCloser) {
+func (ap *ActivePlot) processLogs(in io.ReadCloser) {
 	reader := bufio.NewReader(in)
 	var logFile *os.File
 	for {
@@ -287,7 +287,7 @@ func (ap *activePlot) processLogs(in io.ReadCloser) {
 	return
 }
 
-func (ap *activePlot) cleanup() {
+func (ap *ActivePlot) cleanup() {
 	if len(ap.ID) == 0 {
 		return
 	}

--- a/internal/client.go
+++ b/internal/client.go
@@ -45,7 +45,7 @@ func (client *Client) ProcessLoop(hostList string) {
 	client.msg = map[string]*Msg{}
 
 	gob.Register(Msg{})
-	gob.Register(activePlot{})
+	gob.Register(ActivePlot{})
 
 	client.setupUI()
 
@@ -252,7 +252,7 @@ func (apd *activePlotsData) Strings() []string {
 	}
 }
 
-func (client *Client) makeActivePlotsData(host string, p *activePlot) *activePlotsData {
+func (client *Client) makeActivePlotsData(host string, p *ActivePlot) *activePlotsData {
 	apd := &activePlotsData{}
 	apd.Host = host
 	apd.PlotID = p.ID
@@ -519,7 +519,7 @@ func (apd *archivedPlotData) Strings() []string {
 	}
 }
 
-func (client *Client) makeArchivedPlotData(host string, p *activePlot) *archivedPlotData {
+func (client *Client) makeArchivedPlotData(host string, p *ActivePlot) *archivedPlotData {
 	apd := &archivedPlotData{}
 	apd.Host = host
 	apd.PlotID = p.ID

--- a/internal/client.go
+++ b/internal/client.go
@@ -27,7 +27,7 @@ type Client struct {
 	archivedTableActive bool
 	activeLogs          map[string][]string
 	archivedLogs        map[string][]string
-	logPlotId           string
+	logPlotID           string
 }
 
 var httpClient = &http.Client{
@@ -45,7 +45,7 @@ func (client *Client) ProcessLoop(hostList string) {
 	client.msg = map[string]*Msg{}
 
 	gob.Register(Msg{})
-	gob.Register(ActivePlot{})
+	gob.Register(activePlot{})
 
 	client.setupUI()
 
@@ -73,18 +73,18 @@ func (client *Client) getServerData(host string) (*Msg, error) {
 		return nil, err
 	}
 
-	if resp, err := httpClient.Do(req); err == nil {
-		defer resp.Body.Close()
-		var msg Msg
-		decoder := gob.NewDecoder(resp.Body)
-		if err := decoder.Decode(&msg); err == nil {
-			return &msg, nil
-		} else {
-			return nil, fmt.Errorf("Failed to decode message: %w", err)
-		}
-	} else {
+	resp, err := httpClient.Do(req)
+	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+	var msg Msg
+	decoder := gob.NewDecoder(resp.Body)
+	err = decoder.Decode(&msg)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decode message: %w", err)
+	}
+	return &msg, nil
 }
 
 func (client *Client) checkServer(host string) {
@@ -104,12 +104,12 @@ func (client *Client) checkServer(host string) {
 		client.drawDestDirsTable()
 		client.drawArchivedPlotsTable()
 
-		log, ok := client.activeLogs[client.logPlotId]
+		log, ok := client.activeLogs[client.logPlotID]
 		if !ok {
-			log, ok = client.archivedLogs[client.logPlotId]
+			log, ok = client.archivedLogs[client.logPlotID]
 		}
 		if ok {
-			client.logTextbox.SetTitle(fmt.Sprintf(" Log (%s) ", shortenPlotId(client.logPlotId)))
+			client.logTextbox.SetTitle(fmt.Sprintf(" Log (%s) ", shortenPlotID(client.logPlotID)))
 			client.logTextbox.SetText(strings.Join(log, ""))
 			client.logTextbox.ScrollToEnd()
 		}
@@ -208,7 +208,7 @@ func (client *Client) setupUI() {
 	client.app.EnableMouse(true)
 }
 
-func shortenPlotId(id string) string {
+func shortenPlotID(id string) string {
 	if len(id) < 20 {
 		return ""
 	}
@@ -219,7 +219,7 @@ func shortenPlotId(id string) string {
 
 type activePlotsData struct {
 	Host      string        `header:"Host"`
-	PlotId    string        `header:"Plot ID"`
+	PlotID    string        `header:"Plot ID"`
 	Status    int           `header:"Status"`
 	Phase     int           `header:"Phase"    data-align:"right"`
 	Progress  int           `header:"Progress" data-align:"right"`
@@ -232,30 +232,30 @@ type activePlotsData struct {
 func (apd *activePlotsData) Strings() []string {
 	status := "Unknown"
 	switch apd.Status {
-	case PlotRunning:
+	case plotRunning:
 		status = "Running"
-	case PlotError:
+	case plotError:
 		status = "Errored"
-	case PlotFinished:
+	case plotFinished:
 		status = "Finished"
 	}
 	return []string{
 		apd.Host,
-		shortenPlotId(apd.PlotId),
+		shortenPlotID(apd.PlotID),
 		status,
 		fmt.Sprintf("%d/4", apd.Phase),
 		fmt.Sprintf("%d%%", apd.Progress),
 		apd.StartTime.Format("2006-01-02 15:04:05"),
-		DurationString(apd.Duration),
+		durationString(apd.Duration),
 		apd.PlotDir,
 		apd.DestDir,
 	}
 }
 
-func (client *Client) makeActivePlotsData(host string, p *ActivePlot) *activePlotsData {
+func (client *Client) makeActivePlotsData(host string, p *activePlot) *activePlotsData {
 	apd := &activePlotsData{}
 	apd.Host = host
-	apd.PlotId = p.Id
+	apd.PlotID = p.ID
 	apd.Status = p.State
 	apd.Phase = p.getCurrentPhase()
 	apd.Progress = p.getProgress()
@@ -277,14 +277,14 @@ func (client *Client) drawActivePlotsTable() {
 
 	for host, msg := range client.msg {
 		for _, plot := range msg.Actives {
-			delete(keysToRemove, plot.Id)
-			client.activeLogs[plot.Id] = plot.Tail
-			client.activePlotsTable.SetRowData(plot.Id, client.makeActivePlotsData(host, plot))
+			delete(keysToRemove, plot.ID)
+			client.activeLogs[plot.ID] = plot.Tail
+			client.activePlotsTable.SetRowData(plot.ID, client.makeActivePlotsData(host, plot))
 			activePlotsCount++
 		}
 	}
 
-	for key, _ := range keysToRemove {
+	for key := range keysToRemove {
 		client.activePlotsTable.ClearRowData(key)
 	}
 
@@ -292,10 +292,10 @@ func (client *Client) drawActivePlotsTable() {
 }
 
 func (client *Client) selectActivePlot(key string) {
-	client.logPlotId = key
+	client.logPlotID = key
 	client.archivedPlotsTable.SetSelectedStyle(tcell.StyleDefault.Attributes(tcell.AttrReverse | tcell.AttrDim))
 	client.activePlotsTable.SetSelectedStyle(tcell.StyleDefault.Attributes(tcell.AttrReverse | tcell.AttrBold))
-	client.logTextbox.SetTitle(fmt.Sprintf(" Log (%s) ", shortenPlotId(client.logPlotId)))
+	client.logTextbox.SetTitle(fmt.Sprintf(" Log (%s) ", shortenPlotID(client.logPlotID)))
 	if log, found := client.activeLogs[key]; found {
 		client.logTextbox.SetText(strings.Join(log, ""))
 		client.logTextbox.ScrollToEnd()
@@ -322,11 +322,11 @@ func (pdd *plotDirData) Strings() []string {
 	return []string{
 		pdd.Host,
 		pdd.PlotDir,
-		SpaceString(pdd.AvailableBytes),
-		DurationString(pdd.AvgPhase1),
-		DurationString(pdd.AvgPhase2),
-		DurationString(pdd.AvgPhase3),
-		DurationString(pdd.AvgPhase4),
+		spaceString(pdd.AvailableBytes),
+		durationString(pdd.AvgPhase1),
+		durationString(pdd.AvgPhase2),
+		durationString(pdd.AvgPhase3),
+		durationString(pdd.AvgPhase4),
 		fmt.Sprintf("%d", pdd.Count),
 		fmt.Sprintf("%d", pdd.Failed),
 	}
@@ -356,13 +356,13 @@ func (client *Client) makePlotDirsData() map[string]*plotDirData {
 				plotDirs[host+"||"+plot.PlotDir] = pdd
 			}
 			switch plot.State {
-			case PlotFinished:
+			case plotFinished:
 				pdd.AvgPhase1 += plot.getPhaseTime(1).Sub(plot.getPhaseTime(0))
 				pdd.AvgPhase2 += plot.getPhaseTime(2).Sub(plot.getPhaseTime(1))
 				pdd.AvgPhase3 += plot.getPhaseTime(3).Sub(plot.getPhaseTime(2))
 				pdd.AvgPhase4 += plot.getPhaseTime(4).Sub(plot.getPhaseTime(3))
 				pdd.Count++
-			case PlotError, PlotKilled:
+			case plotError, plotKilled:
 				pdd.Failed++
 			}
 		}
@@ -392,7 +392,7 @@ func (client *Client) drawPlotDirsTable() {
 		client.plotDirsTable.SetRowData(key, pdd)
 	}
 
-	for key, _ := range keysToRemove {
+	for key := range keysToRemove {
 		client.plotDirsTable.ClearRowData(key)
 	}
 
@@ -414,8 +414,8 @@ func (ddd *destDirData) Strings() []string {
 	return []string{
 		ddd.Host,
 		ddd.DestDir,
-		SpaceString(ddd.AvailableBytes),
-		DurationString(ddd.AvgPlotTime),
+		spaceString(ddd.AvailableBytes),
+		durationString(ddd.AvgPlotTime),
 		fmt.Sprintf("%d", ddd.Count),
 		fmt.Sprintf("%d", ddd.Failed),
 	}
@@ -445,10 +445,10 @@ func (client *Client) makeDestDirsData() map[string]*destDirData {
 				destDirs[host+"||"+plot.TargetDir] = ddd
 			}
 			switch plot.State {
-			case PlotFinished:
+			case plotFinished:
 				ddd.AvgPlotTime += plot.getPhaseTime(4).Sub(plot.getPhaseTime(0))
 				ddd.Count++
-			case PlotError, PlotKilled:
+			case plotError, plotKilled:
 				ddd.Failed++
 			}
 		}
@@ -475,7 +475,7 @@ func (client *Client) drawDestDirsTable() {
 		client.destDirsTable.SetRowData(key, ddd)
 	}
 
-	for key, _ := range keysToRemove {
+	for key := range keysToRemove {
 		client.destDirsTable.ClearRowData(key)
 	}
 
@@ -486,7 +486,7 @@ func (client *Client) drawDestDirsTable() {
 
 type archivedPlotData struct {
 	Host      string        `header:"Host"`
-	PlotId    string        `header:"Plot Id"`
+	PlotID    string        `header:"Plot Id"`
 	Status    int           `header:"Status"`
 	Phase     int           `header:"Phase" data-align:"right"`
 	StartTime time.Time     `header:"Start Time"`
@@ -499,30 +499,30 @@ type archivedPlotData struct {
 func (apd *archivedPlotData) Strings() []string {
 	status := "Unknown"
 	switch apd.Status {
-	case PlotRunning:
+	case plotRunning:
 		status = "Running"
-	case PlotError:
+	case plotError:
 		status = "Errored"
-	case PlotFinished:
+	case plotFinished:
 		status = "Finished"
 	}
 	return []string{
 		apd.Host,
-		shortenPlotId(apd.PlotId),
+		shortenPlotID(apd.PlotID),
 		status,
 		fmt.Sprintf("%d/4", apd.Phase),
 		apd.StartTime.Format("2006-01-02 15:04:05"),
 		apd.EndTime.Format("2006-01-02 15:04:05"),
-		DurationString(apd.Duration),
+		durationString(apd.Duration),
 		apd.PlotDir,
 		apd.DestDir,
 	}
 }
 
-func (client *Client) makeArchivedPlotData(host string, p *ActivePlot) *archivedPlotData {
+func (client *Client) makeArchivedPlotData(host string, p *activePlot) *archivedPlotData {
 	apd := &archivedPlotData{}
 	apd.Host = host
-	apd.PlotId = p.Id
+	apd.PlotID = p.ID
 	apd.Status = p.State
 	apd.Phase = p.getCurrentPhase()
 	apd.StartTime = p.getPhaseTime(0)
@@ -545,21 +545,21 @@ func (client *Client) drawArchivedPlotsTable() {
 
 	for host, msg := range client.msg {
 		for _, plot := range msg.Archived {
-			delete(keysToRemove, plot.Id)
-			client.archivedLogs[plot.Id] = plot.Tail
-			client.archivedPlotsTable.SetRowData(plot.Id, client.makeArchivedPlotData(host, plot))
+			delete(keysToRemove, plot.ID)
+			client.archivedLogs[plot.ID] = plot.Tail
+			client.archivedPlotsTable.SetRowData(plot.ID, client.makeArchivedPlotData(host, plot))
 			switch plot.State {
-			case PlotFinished:
+			case plotFinished:
 				archivedPlotsSuccess++
-			case PlotKilled:
+			case plotKilled:
 				archivedPlotsFailed++
-			case PlotError:
+			case plotError:
 				archivedPlotsFailed++
 			}
 		}
 	}
 
-	for key, _ := range keysToRemove {
+	for key := range keysToRemove {
 		client.archivedPlotsTable.ClearRowData(key)
 	}
 
@@ -571,10 +571,10 @@ func (client *Client) drawArchivedPlotsTable() {
 }
 
 func (client *Client) selectArchivedPlot(key string) {
-	client.logPlotId = key
+	client.logPlotID = key
 	client.activePlotsTable.SetSelectedStyle(tcell.StyleDefault.Attributes(tcell.AttrReverse | tcell.AttrDim))
 	client.archivedPlotsTable.SetSelectedStyle(tcell.StyleDefault.Attributes(tcell.AttrReverse | tcell.AttrBold))
-	client.logTextbox.SetTitle(fmt.Sprintf(" Log (%s) ", shortenPlotId(client.logPlotId)))
+	client.logTextbox.SetTitle(fmt.Sprintf(" Log (%s) ", shortenPlotID(client.logPlotID)))
 	if log, found := client.archivedLogs[key]; found {
 		client.logTextbox.SetText(strings.Join(log, ""))
 		client.logTextbox.ScrollToEnd()

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-type Config struct {
+type config struct {
 	TargetDirectory        []string
 	TempDirectory          []string
 	NumberOfParallelPlots  int
@@ -33,7 +33,7 @@ type Config struct {
 
 type PlotConfig struct {
 	ConfigPath    string
-	CurrentConfig *Config
+	CurrentConfig *config
 	LastMod       time.Time
 	Lock          sync.RWMutex
 }
@@ -54,7 +54,7 @@ func (pc *PlotConfig) ProcessConfig() (newConfigLoaded bool) {
 	}
 	defer f.Close()
 	decoder := json.NewDecoder(f)
-	var newConfig Config
+	var newConfig config
 	if err := decoder.Decode(&newConfig); err != nil {
 		log.Printf("Failed to process config file [%s], check your config file for mistake: %s\n", pc.ConfigPath, err)
 		return

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -31,7 +31,7 @@ type config struct {
 	SavePlotLogDir         string
 }
 
-type PlotConfig struct {
+type plotConfig struct {
 	ConfigPath    string
 	CurrentConfig *config
 	LastMod       time.Time

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -38,7 +38,7 @@ type plotConfig struct {
 	Lock          sync.RWMutex
 }
 
-func (pc *PlotConfig) ProcessConfig() (newConfigLoaded bool) {
+func (pc *plotConfig) ProcessConfig() (newConfigLoaded bool) {
 	fs, err := os.Lstat(pc.ConfigPath)
 	if err != nil {
 		log.Printf("Failed to open config file [%s]: %s\n", pc.ConfigPath, err)

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -39,28 +39,30 @@ type PlotConfig struct {
 }
 
 func (pc *PlotConfig) ProcessConfig() (newConfigLoaded bool) {
-	if fs, err := os.Lstat(pc.ConfigPath); err != nil {
+	fs, err := os.Lstat(pc.ConfigPath)
+	if err != nil {
 		log.Printf("Failed to open config file [%s]: %s\n", pc.ConfigPath, err)
-	} else {
-		if pc.LastMod != fs.ModTime() {
-			if f, err := os.Open(pc.ConfigPath); err != nil {
-				log.Printf("Failed to open config file [%s]: %s\n", pc.ConfigPath, err)
-			} else {
-				defer f.Close()
-				decoder := json.NewDecoder(f)
-				var newConfig Config
-				if err := decoder.Decode(&newConfig); err != nil {
-					log.Printf("Failed to process config file [%s], check your config file for mistake: %s\n", pc.ConfigPath, err)
-				} else {
-					pc.Lock.Lock()
-					pc.CurrentConfig = &newConfig
-					pc.Lock.Unlock()
-					log.Printf("New configuration loaded")
-					newConfigLoaded = true
-				}
-			}
-			pc.LastMod = fs.ModTime()
-		}
+		return
 	}
-	return
+	if pc.LastMod == fs.ModTime() {
+		return
+	}
+	f, err := os.Open(pc.ConfigPath)
+	if err != nil {
+		log.Printf("Failed to open config file [%s]: %s\n", pc.ConfigPath, err)
+		return
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	var newConfig Config
+	if err := decoder.Decode(&newConfig); err != nil {
+		log.Printf("Failed to process config file [%s], check your config file for mistake: %s\n", pc.ConfigPath, err)
+		return
+	}
+	pc.Lock.Lock()
+	pc.CurrentConfig = &newConfig
+	pc.Lock.Unlock()
+	log.Printf("New configuration loaded")
+	pc.LastMod = fs.ModTime()
+	return true
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -15,8 +15,8 @@ import (
 
 type Server struct {
 	config               *PlotConfig
-	active               map[int64]*activePlot
-	archive              []*activePlot
+	active               map[int64]*ActivePlot
+	archive              []*ActivePlot
 	currentTemp          int
 	currentTarget        int
 	targetDelayStartTime time.Time
@@ -25,7 +25,7 @@ type Server struct {
 
 func (server *Server) ProcessLoop(configPath string, port int) {
 	gob.Register(Msg{})
-	gob.Register(activePlot{})
+	gob.Register(ActivePlot{})
 	go func() {
 		if err := http.ListenAndServe(fmt.Sprintf(":%d", port), server); err != nil {
 			log.Fatalf("Failed to start webserver: %s", err)
@@ -35,7 +35,7 @@ func (server *Server) ProcessLoop(configPath string, port int) {
 	server.config = &PlotConfig{
 		ConfigPath: configPath,
 	}
-	server.active = map[int64]*activePlot{}
+	server.active = map[int64]*ActivePlot{}
 	server.createPlot(time.Now())
 	ticker := time.NewTicker(time.Minute)
 	for t := range ticker.C {
@@ -85,7 +85,7 @@ func (server *Server) createNewPlot(config *Config) {
 		server.currentTemp = 0
 	}
 	if config.MaxActivePlotPerPhase1 > 0 {
-		getPhase1 := func(plot *activePlot) bool {
+		getPhase1 := func(plot *ActivePlot) bool {
 			if strings.HasPrefix(plot.Phase, "1/4") {
 				return true
 			}
@@ -131,7 +131,7 @@ func (server *Server) createNewPlot(config *Config) {
 	}
 
 	t := time.Now()
-	plot := &activePlot{
+	plot := &ActivePlot{
 		PlotID:           t.Unix(),
 		TargetDir:        targetDir,
 		PlotDir:          plotDir,
@@ -220,8 +220,8 @@ func (server *Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 }
 
 type Msg struct {
-	Actives    []*activePlot
-	Archived   []*activePlot
+	Actives    []*ActivePlot
+	Archived   []*ActivePlot
 	TempDirs   map[string]uint64
 	TargetDirs map[string]uint64
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Server struct {
-	config               *PlotConfig
+	config               *plotConfig
 	active               map[int64]*ActivePlot
 	archive              []*ActivePlot
 	currentTemp          int
@@ -32,7 +32,7 @@ func (server *Server) ProcessLoop(configPath string, port int) {
 		}
 	}()
 
-	server.config = &PlotConfig{
+	server.config = &plotConfig{
 		ConfigPath: configPath,
 	}
 	server.active = map[int64]*ActivePlot{}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func DurationString(d time.Duration) string {
+func durationString(d time.Duration) string {
 	hour := d / time.Hour
 	d = d - hour*(60*60*1e9)
 	mins := d / time.Minute
@@ -15,12 +15,12 @@ func DurationString(d time.Duration) string {
 	return fmt.Sprintf("%02d:%02d:%02d", hour, mins, secs)
 }
 
-func SpaceString(s uint64) string {
+func spaceString(s uint64) string {
 	if s == math.MaxUint64 {
 		return "???"
 	}
-	if s > 1000 * GB {
-		return fmt.Sprintf("%0.2f TiB", float64(s) / float64(TB))
+	if s > 1000*gb {
+		return fmt.Sprintf("%0.2f TiB", float64(s)/float64(tb))
 	}
-	return fmt.Sprintf("%d GiB", s / GB)
+	return fmt.Sprintf("%d GiB", s/gb)
 }

--- a/internal/widget/sortedTable.go
+++ b/internal/widget/sortedTable.go
@@ -10,13 +10,13 @@ import (
 	"github.com/rivo/tview"
 )
 
-type SortableRow interface {
+type sortableRow interface {
 	Strings() []string
 }
 
 type tableRow struct {
 	key  string
-	data SortableRow
+	data sortableRow
 }
 
 // SortedTable is a wrapper around tview.Table which provides sortable column headers.  Rows are
@@ -199,7 +199,7 @@ func (st *SortedTable) Keys() []string {
 	return keys
 }
 
-func (st *SortedTable) SetRowData(key string, data SortableRow) *SortedTable {
+func (st *SortedTable) SetRowData(key string, data sortableRow) *SortedTable {
 	found := false
 	for idx, dr := range st.values {
 		if dr.key == key {


### PR DESCRIPTION
This PR is mostly over industry standards for Go code. Feel free to cherry pick.

I used go-lint and tackled as many warnings as I could. The remaining warning are about doc comments. Example: `exported type Client should have comment or be unexported`

**Fix:** Replace `fmt.Sprintf` with `log.Printf` for plot log file creation error
**Change**: Replace `fmt.Printf` with `log.Printf` at `internal/server.go:57`

## Everything else
* Ran `go mod tidy`. Removed unused `github.com/gdamore/tcell v1.4.0` from `go.mod`.
* Unexport Items. Items that were exported but unused externally have been renamed. `ActivePlot` => `activePlot`
* Rename `Id` to `ID`. `PlotId` => `PlotID`
* Removed a commented line of debugging code.
* Refactored unnecessary else blocks at `internal/client.go:76`.