### PR TITLE
Only count running plots when doing phase 1 detection

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -85,17 +84,9 @@ func (server *Server) createNewPlot(config *Config) {
 		server.currentTemp = 0
 	}
 	if config.MaxActivePlotPerPhase1 > 0 {
-		getPhase1 := func(plot *ActivePlot) bool {
-			if strings.HasPrefix(plot.Phase, "1/4") {
-				return true
-			}
-			return false
-		}
-
 		var sum int
-
 		for _, plot := range server.active {
-			if getPhase1(plot) {
+			if plot.State == PlotRunning && plot.getCurrentPhase() <= 1 {
 				sum++
 			}
 		}


### PR DESCRIPTION
If a plot is killed or has an error during phase 1, it is still counted towards the total.  This also simplifies the code generally, and counts plots which are "warming up" (not yet running, but will be).

The warming up case is not one that would generally occur, but I reduce the server check interval down from 1 minute as part of testing.  Theoretically it might occur if a system is super busy, and manages to take over a minute before the plot officially moves to phase 1.