### PR TITLE
Add a ChiaRoot configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Pre-built binaries available for 64-bits Linux, Windows and MacOS (I've only tes
 plotng-server -config <json config file> -port <plotter port number, default: 8484>
 `
 
-**Please note**: chia environment should be activated before starting plotng-server
+**Please note**: chia environment should be activated before starting plotng-server, or ChiaRoot should be set in the configuration file.
 
 ## Running Monitoring UI (run anywhere)
 
@@ -45,13 +45,14 @@ eg. plotng-client -host plotter1:8484,plotter2,plotter3:8485
 
 ## Configuration File (JSON format)
 
-
+```json
     {
         "Fingerprint": "",
         "FarmerPublicKey": "",
         "PoolPublicKey": "",
         "Threads": 0,
         "Buffers": 0,
+        "DisableBitField": false,
         "NumberOfParallelPlots": 1,
         "TempDirectory": ["/media/eddie/tmp1", "/media/eddie/tmp2", "/media/eddie/tmp3"],
         "TargetDirectory": ["/media/eddie/target1", "/media/eddie/target2"],
@@ -60,14 +61,15 @@ eg. plotng-client -host plotter1:8484,plotter2,plotter3:8485
         "DiskSpaceCheck": false,
         "DelaysBetweenPlot": 0,
         "MaxActivePlotPerTarget": 0,
-        "DisableBitField": false,
         "MaxActivePlotPerTemp": 0,
         "MaxActivePlotPerPhase1": 0,
         "UseTargetForTmp2": false,
         "BucketSize": 0,
         "SavePlotLogDir": "",
-        "PlotSize": 32
+        "PlotSize": 32,
+        "ChiaRoot": ""
     }
+```
 
 Please note for Windows, please use capital drive letter and '/'  eg.  "D:/temp"
 
@@ -93,5 +95,6 @@ Please note for Windows, please use capital drive letter and '/'  eg.  "D:/temp"
 - BucketSize : specify custom busket size (default: 0 - use chia default)
 - SavePlotLogDir : saves plotting logs to this directory. logs are not saved if no directory is provided (default: "")
 - PlotSize : plot size, default to k32 is not set.  If set then it also pick sensible buffers for the given size.
+- ChiaRoot : the directory to find the chia binary in (typically this should remain as an empty string and the environment should be activated instead)
 
 Please note PlotNG now skips any destination directory which have less than 105GB of disk space, if you set DiskSpaceCheck to true.

--- a/config.json
+++ b/config.json
@@ -18,5 +18,6 @@
   "UseTargetForTmp2": false,
   "BucketSize": 0,
   "SavePlotLogDir": "",
-  "PlotSize": 32
+  "PlotSize": 32,
+  "ChiaRoot": ""
 }

--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -129,7 +130,7 @@ func (ap *ActivePlot) String(showLog bool) string {
 	return s
 }
 
-func (ap *ActivePlot) RunPlot() {
+func (ap *ActivePlot) RunPlot(config *Config) {
 	ap.StartTime = time.Now()
 	defer func() {
 		ap.EndTime = time.Now()
@@ -190,7 +191,7 @@ func (ap *ActivePlot) RunPlot() {
 		args = append(args, fmt.Sprintf("-u%d", ap.BucketSize))
 	}
 
-	cmd := exec.Command("chia", args...)
+	cmd := exec.Command(path.Join(config.ChiaRoot, "chia"), args...)
 	ap.State = PlotRunning
 	if stderr, err := cmd.StderrPipe(); err != nil {
 		ap.State = PlotError

--- a/internal/plotConfig.go
+++ b/internal/plotConfig.go
@@ -29,6 +29,7 @@ type Config struct {
 	UseTargetForTmp2       bool
 	BucketSize             int
 	SavePlotLogDir         string
+	ChiaRoot               string
 }
 
 type PlotConfig struct {

--- a/internal/server.go
+++ b/internal/server.go
@@ -150,7 +150,7 @@ func (server *Server) createNewPlot(config *Config) {
 		State:            PlotRunning,
 	}
 	server.active[plot.PlotId] = plot
-	go plot.RunPlot()
+	go plot.RunPlot(config)
 }
 
 func (server *Server) countActiveTarget(path string) (count uint64) {


### PR DESCRIPTION
This allows for configuring different chia roots.  Not typically useful for most users, but helpful when doing development with atypical setups