### PR TITLE
Automatically adds --override-k if the plot size is under 32

### DIFF
--- a/internal/activePlot.go
+++ b/internal/activePlot.go
@@ -155,6 +155,9 @@ func (ap *ActivePlot) RunPlot(config *Config) {
 	}
 	if ap.PlotSize > 0 {
 		args = append(args, fmt.Sprintf("-k%d", ap.PlotSize))
+		if ap.PlotSize < 32 {
+			args = append(args, "--override-k")
+		}
 	} else {
 		args = append(args, "-k32")
 	}


### PR DESCRIPTION
This is mainly useful for development to get some data in the system with faster plots.

I think it's ok with just this, but I could add an extra (maybe hidden?) configuration option for an extra layer of safety against accidentally enabling this if you want.