### PR TITLE
Attempts to fix an issue where mouse input under PuTTy is not recognized

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The UI can run on any host and point back to the server using the host and port 
 
 
 ```
-plotng-client -host <comma separated list of plotters host name or IP with/without port number>
+plotng-client -hosts <comma separated list of plotters host name or IP with/without port number> -alternate-mouse <optional, may be needed for mouse support through PuTTY)
 
-eg. plotng-client -host plotter1:8484,plotter2,plotter3:8485
+eg. plotng-client -hosts plotter1:8484,plotter2,plotter3:8485
 ```
 
 ## Configuration File (JSON format)

--- a/cmd/plotng-client/main.go
+++ b/cmd/plotng-client/main.go
@@ -8,12 +8,15 @@ import (
 
 func main() {
 	hosts := flag.String("hosts", "localhost", "hosts to query, separated by comma, default: localhost")
+	alternateMouse := flag.Bool("alternate-mouse", false, "use alternate mouse setup (for PuTTy)")
 
 	flag.Parse()
 	if flag.Parsed() == false {
 		flag.Usage()
 		return
 	}
-	client := &internal.Client{}
+	client := &internal.Client{
+		AlternateMouse: *alternateMouse,
+	}
 	client.ProcessLoop(*hosts)
 }


### PR DESCRIPTION
tcell.Screen exposes an EnableMouse with the option to specify which type of mouse events to capture (click, drag, all).  Unfortunately putty doesn't currently support "all", which is the default, so we need to specify either click or drag.

This problem is further compounded by tview.Application not exposing the underlying Screen directly.  It does however use a Screen if we provide it; allowing us to create one, configure the mouse, and then use it.  We don't call Application.EnableMouse because that will override the setting we've used.

This is probably going to cause a conflict in the README.md of #79, but I'll clean it up after this or that is merged).

Fixes #77